### PR TITLE
iCloud session dead check

### DIFF
--- a/icloud.js
+++ b/icloud.js
@@ -26,7 +26,7 @@ var icloud = {
 		});
 
 		icloud.checkSession(function(err, res, body) {
-			if (err) {
+			if (err || !body) {
 				//session is dead, start new
 				icloud.jar = null;
 				icloud.jar = request.jar();


### PR DESCRIPTION
Added !body to the check in the init function after checkSession.  Verifies the session is still alive.